### PR TITLE
fix: update pipeline to build the project

### DIFF
--- a/components/apicurio-registry/base/.tekton/pipeline.yaml
+++ b/components/apicurio-registry/base/.tekton/pipeline.yaml
@@ -1,57 +1,104 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: docker-build 
-  labels:
-    "pipelines.openshift.io/used-by" : "build-cloud"
-    "pipelines.openshift.io/runtime" : "generic"
-    "pipelines.openshift.io/strategy" : "docker" 
+  name: service-registry-build
 spec:
   params:
-    - description: 'Source Repository URL'
+    - description: "Source Repository URL"
       name: git-url
       type: string
-    - description: 'Fully Qualified Output Image'
+    - description: "Revision of the Source Repository"
+      name: revision
+      type: string
+      default: main
+    - description: "Fully Qualified Output Image"
       name: output-image
       type: string
-    - default: .
-      description: The path to your source code
-      name: PATH_CONTEXT
+    - description: The path to your source code
+      name: path-context
       type: string
-    - name: dockerfile
+      default: .
+    - description: Path to the Dockerfile
+      name: dockerfile
       type: string
-    - name: revision
-      type: string
+      default: Dockerfile
   tasks:
-    - name: quick-build-test 
+    - name: appstudio-init
+      params:
+        - name: image-url
+          value: "$(params.output-image)"
       taskRef:
         kind: ClusterTask
-        name: image-exists
-      params:
-        - name: image-url 
-          value: "$(params.output-image)"
+        name: appstudio-init
       workspaces:
         - name: source
           workspace: workspace
-    - name: clone-repository      
+        - name: registry-auth
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
+    - name: clone-repository
       when:
-      - input: $(tasks.quick-build-test.results.exists) 
-        operator: in
-        values: ["false"]
+        - input: $(tasks.appstudio-init.results.exists)
+          operator: in
+          values: ["false"]
       runAfter:
-        - quick-build-test 
+        - appstudio-init
       params:
         - name: url
           value: $(params.git-url)
         - name: revision
-          value: $(params.revision)
+          value: "$(params.revision)"
       taskRef:
         kind: ClusterTask
         name: git-clone
       workspaces:
         - name: output
           workspace: workspace
-    - name: build-container 
+    - name: appstudio-configure-build
+      runAfter:
+        - appstudio-init
+      when:
+        - input: $(tasks.appstudio-init.results.exists)
+          operator: in
+          values: ["false"]
+      taskRef:
+        kind: ClusterTask
+        name: appstudio-configure-build
+      workspaces:
+        - name: source
+          workspace: workspace
+        - name: registry-auth
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
+    - name: build-java
+      params:
+        - name: GOALS
+          value:
+            - clean
+            - install
+            - -Pprod
+            - -Pno-docker
+            - -Dskip.yarn
+            - -Psql
+            - -Pmultitenancy
+            - -Dmaven.javadoc.skip=true
+            - --no-transfer-progress
+            - -DtrimStackTrace=false
+            - -DskipTests
+      runAfter:
+        - appstudio-configure-build
+      taskRef:
+        kind: ClusterTask
+        name: maven
+      workspaces:
+        - name: maven-settings
+          workspace: workspace
+          subPath: maven-settings
+        - name: source
+          workspace: workspace
+    - name: build-container
       params:
         - name: IMAGE
           value: >-
@@ -62,15 +109,19 @@ spec:
         - name: STORAGE_DRIVER
           value: vfs
         - name: DOCKERFILE
-          value: ./Dockerfile
+          value: $(params.dockerfile)
         - name: CONTEXT
-          value: /workspace/source
+          value: $(params.path-context)
         - name: TLSVERIFY
-          value: 'true'
+          value: "true"
         - name: FORMAT
           value: oci
+        - name: BUILD_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+        - name: PUSH_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
-        - clone-repository
+        - build-java
       taskRef:
         kind: ClusterTask
         name: buildah
@@ -79,69 +130,37 @@ spec:
           workspace: workspace
     - name: show-summary
       runAfter:
-        - build-container 
+        - build-container
       taskRef:
         kind: ClusterTask
-        name: openshift-client
+        name: appstudio-summary
       params:
-        - name: SCRIPT 
-          value: |
-            #!/usr/bin/env bash
-            echo  
-            echo "Build Summary:"
-            echo
-            echo "Build repository: $(params.git-url)" 
-            echo "Generated Image is in : $(params.output-image)"  
-            echo  
-            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/repo=$(params.git-url)
-            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/image=$(params.output-image)
-
-            echo "Output is in the following annotations:"
-            
-            echo "Build Repo is in 'build.appstudio.openshift.io/repo' "
-            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/repo}"' 
-            
-            echo "Build Image is in 'build.appstudio.openshift.io/image' "
-            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/image}"' 
-
-            echo End Summary
-      workspaces:
-        - name: manifest-dir 
-          workspace: workspace  
-    - name: skip-rebuild-summary  
+        - name: pipeline-run-name
+          value: "$(context.pipelineRun.name)"
+        - name: git-url
+          value: "$(params.git-url)"
+        - name: image-url
+          value: $(params.output-image)
+    - name: skip-rebuild-summary
       when:
-      - input: $(tasks.quick-build-test.results.exists) 
-        operator: in
-        values: ["true"]  
+        - input: $(tasks.appstudio-init.results.exists)
+          operator: in
+          values: ["true"]
       runAfter:
-        - quick-build-test
+        - appstudio-init
       taskRef:
         kind: ClusterTask
-        name: openshift-client 
+        name: appstudio-summary
       params:
-        - name: SCRIPT 
-          value: |
-            #!/usr/bin/env bash
-            echo  
-            echo "Build Summary:"
-            echo
-            echo "Build repository: $(params.git-url)" 
-            echo "Generated Image is in : $(params.output-image)"  
-            echo  
-            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/repo=$(params.git-url)
-            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/image=$(params.output-image)
-
-            echo "Output is in the following annotations:"
-            
-            echo "Build Repo is in 'build.appstudio.openshift.io/repo' "
-            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/repo}"' 
-            
-            echo "Build Image is in 'build.appstudio.openshift.io/image' "
-            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/image}"' 
-
-            echo End Summary  
-      workspaces:
-        - name: manifest-dir 
-          workspace: workspace
+        - name: pipeline-run-name
+          value: "$(context.pipelineRun.name)"
+        - name: git-url
+          value: "$(params.git-url)"
+        - name: image-url
+          value: $(params.output-image)
   workspaces:
     - name: workspace
+    - name: registry-auth
+      optional: true
+    - name: git-auth
+      optional: true

--- a/components/apicurio-registry/base/application.yaml
+++ b/components/apicurio-registry/base/application.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: apicurio-registry
-          image: quay.io/apicurio/apicurio-registry-sql:latest-snapshot
+          image: quay.io/goldmann/srs-service-registry:hacbs
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -94,7 +94,7 @@ spec:
             failureThreshold: 3
           terminationMessagePath: /dev/termination-log
         - name: tenant-manager
-          image: quay.io/apicurio/apicurio-registry-tenant-manager-api:latest-snapshot
+          image: quay.io/goldmann/srs-tenant-manager:hacbs
           imagePullPolicy: Always
           ports:
             - containerPort: 8585
@@ -132,7 +132,7 @@ spec:
               memory: 600Mi
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: /q/health/live
               port: 8585
               scheme: HTTP
             initialDelaySeconds: 5
@@ -142,7 +142,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health/ready
+              path: /q/health/ready
               port: 8585
               scheme: HTTP
             initialDelaySeconds: 5


### PR DESCRIPTION
* Uses new skeleton for the pipeline
* Uses the `maven` ClusterTask to execute Java builds
* Udated liveness and readiness probes


To trigger a build of service-registry:

```yaml
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: service-registry-
spec:
  params:
    - name: git-url
      value: "https://github.com/goldmann/apicurio-registry"
    - name: revision
      value: hacbs
    - name: output-image
      value: "quay.io/goldmann/srs-service-registry:hacbs"
    - name: dockerfile
      value: "Dockerfile.sql.jvm"
    - name: path-context
      value: "distro/docker/target/docker"
  pipelineRef:
    name: service-registry-build
  workspaces:
    - name: workspace
      persistentVolumeClaim:
        claimName: app-studio-default-workspace
      subPath: "apicurio-registry/hacbs"
    - name: registry-auth
      secret:
        secretName: quay-registry-secret
    - name: git-auth
      secret:
        secretName: git-repo-secret
```

And tenant manager:

```yaml
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: service-registry-
spec:
  params:
    - name: git-url
      value: "https://github.com/goldmann/apicurio-registry"
    - name: revision
      value: hacbs
    - name: output-image
      value: "quay.io/goldmann/srs-tenant-manager:hacbs"
    - name: dockerfile
      value: "src/main/docker/Dockerfile.jvm"
    - name: path-context
      value: "multitenancy/tenant-manager-api"
  pipelineRef:
    name: service-registry-build
  workspaces:
    - name: workspace
      persistentVolumeClaim:
        claimName: app-studio-default-workspace
      subPath: "apicurio-registry/hacbs"
    - name: registry-auth
      secret:
        secretName: quay-registry-secret
    - name: git-auth
      secret:
        secretName: git-repo-secret

```